### PR TITLE
[#5] Remove magento/module-sales-inventory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
     "magento/module-inventory-shipping-admin-ui": "*",
     "magento/module-inventory-source-deduction-api": "*",
     "magento/module-inventory-source-selection": "*",
-    "magento/module-inventory-source-selection-api": "*",
-    "magento/module-sales-inventory": "*"
+    "magento/module-inventory-source-selection-api": "*"
   }
 }


### PR DESCRIPTION
Fixes #5, module is not part of MSI.